### PR TITLE
Parametrized namespace and application domain

### DIFF
--- a/discodeploy
+++ b/discodeploy
@@ -157,17 +157,10 @@ function cmd_deploy {
     cmd_create_pull_secret
   fi
   cmdexec oc apply -f discovery_template.yaml
-
-  # namespace dependent parameters:
-  DISCOVERY_SERVER_CLUSTER_HOSTNAME="discovery-server.${DISCOVERY_NAMESPACE}.svc.cluster.local"
-  DISCOVERY_REDIS_CLUSTER_HOSTNAME="discovery-redis.${DISCOVERY_NAMESPACE}.svc.cluster.local"
-  DISCOVERY_DBMS_CLUSTER_HOSTNAME="discovery-db.${DISCOVERY_NAMESPACE}.svc.cluster.local"
-
-  cmdexec oc new-app --template=discovery --param=DISCOVERY_SERVER_IMAGE="${DISCOVERY_SERVER_IMAGE}" \
-    --param=APPLICATION_DOMAIN="${APPLICATION_DOMAIN}" \
-    --param=DISCOVERY_SERVER_CLUSTER_HOSTNAME="${DISCOVERY_SERVER_CLUSTER_HOSTNAME}" \
-    --param=DISCOVERY_REDIS_CLUSTER_HOSTNAME="${DISCOVERY_REDIS_CLUSTER_HOSTNAME}" \
-    --param=DISCOVERY_DBMS_CLUSTER_HOSTNAME="${DISCOVERY_DBMS_CLUSTER_HOSTNAME}"
+  cmdexec oc new-app --template=discovery \
+    --param=DISCOVERY_SERVER_IMAGE="${DISCOVERY_SERVER_IMAGE}" \
+    --param=DISCOVERY_NAMESPACE=${DISCOVERY_NAMESPACE} \
+    --param=APPLICATION_DOMAIN="${APPLICATION_DOMAIN}"
 }
 
 function cmd_undeploy {

--- a/discodeploy
+++ b/discodeploy
@@ -13,7 +13,7 @@ export DISCOVERY_NAMESPACE="${DISCOVERY_NAMESPACE:=discovery}"
 
 export DISCOVERY_REGISTRY="${DISCOVERY_REGISTRY:=quay.io}"
 export REGISTRY_USER="${REGISTRY_USER:=quay_user}"
-export REGISTRY_PASSWORD="${REGISTRY_PASSWORD:=quay_password}"
+export REGISTRY_PASSWORD="${REGISTRY_PASSWORD:=}"
 export REGISTRY_EMAIL="${REGISTRY_EMAIL:=quay_user@redhat.com}"
 
 export QUIPUCORDS_IMAGE="quipucords"
@@ -33,7 +33,7 @@ function cmdexec {
 function varupd {
   var="$(echo $1 | tr '[a-z]' '[A-Z]')"
   if [[ "${var}" == *"PASS"* ]]; then
-    echo -n "${var} (********): "
+    echo -n "${var} ($(echo ${!var} | sed 's/./*/g')): "
     read -s value
     echo ""
   else
@@ -58,6 +58,8 @@ function get_env_deploy {
   varupd OCP_USER
   varupd OCP_PASSWORD
   varupd DISCOVERY_NAMESPACE
+  export APPLICATION_DOMAIN="discovery-server-${DISCOVERY_NAMESPACE}.apps-crc.testing"
+  varupd APPLICATION_DOMAIN
   varupd DISCOVERY_REGISTRY
   varupd QUIPUCORDS_IMAGE_TAG
   varupd REGISTRY_USER
@@ -155,7 +157,17 @@ function cmd_deploy {
     cmd_create_pull_secret
   fi
   cmdexec oc apply -f discovery_template.yaml
-  cmdexec oc new-app --template=discovery --param=DISCOVERY_SERVER_IMAGE="${DISCOVERY_SERVER_IMAGE}"
+
+  # namespace dependent parameters:
+  DISCOVERY_SERVER_CLUSTER_HOSTNAME="discovery-server.${DISCOVERY_NAMESPACE}.svc.cluster.local"
+  DISCOVERY_REDIS_CLUSTER_HOSTNAME="discovery-redis.${DISCOVERY_NAMESPACE}.svc.cluster.local"
+  DISCOVERY_DBMS_CLUSTER_HOSTNAME="discovery-db.${DISCOVERY_NAMESPACE}.svc.cluster.local"
+
+  cmdexec oc new-app --template=discovery --param=DISCOVERY_SERVER_IMAGE="${DISCOVERY_SERVER_IMAGE}" \
+    --param=APPLICATION_DOMAIN="${APPLICATION_DOMAIN}" \
+    --param=DISCOVERY_SERVER_CLUSTER_HOSTNAME="${DISCOVERY_SERVER_CLUSTER_HOSTNAME}" \
+    --param=DISCOVERY_REDIS_CLUSTER_HOSTNAME="${DISCOVERY_REDIS_CLUSTER_HOSTNAME}" \
+    --param=DISCOVERY_DBMS_CLUSTER_HOSTNAME="${DISCOVERY_DBMS_CLUSTER_HOSTNAME}"
 }
 
 function cmd_undeploy {
@@ -233,10 +245,11 @@ Environment variables that are honored and prompted for (defaults):
     OCP_USER                   (developer)
     OCP_PASSWORD               (developer)
     DISCOVERY_NAMESPACE        (discovery)
+    APPLICATION_DOMAIN         (discovery-server-discovery.apps-crc.testing)
  
     DISCOVERY_REGISTRY         (quay.io)
     REGISTRY_USER              (quay_user)
-    REGISTRY_PASSWORD          (quay_password)
+    REGISTRY_PASSWORD          ()
     REGISTRY_EMAIL             (quay_user@redhat.com)
  
     QUIPUCORDS_IMAGE_TAG       (latest)

--- a/discovery_template.yaml
+++ b/discovery_template.yaml
@@ -4,7 +4,6 @@ labels:
   template: discovery
 metadata:
   name: discovery
-  namespace: discovery
   annotations:
     description: The Discovery Server application
     tags: discovery
@@ -15,12 +14,10 @@ objects:
   - name: discovery-pull-secret
   metadata:
     name: ${DISCOVERY_SA_NAME}
-    namespace: discovery
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: discovery-data-volume-claim
-    namespace: discovery
   spec:
     accessModes:
     - ReadWriteMany
@@ -32,7 +29,6 @@ objects:
   kind: PersistentVolumeClaim
   metadata:
     name: discovery-log-volume-claim
-    namespace: discovery
   spec:
     accessModes:
     - ReadWriteMany
@@ -44,7 +40,6 @@ objects:
   kind: Service
   metadata:
     name: discovery-server
-    namespace: discovery
   spec:
     selector:
       app: discovery-server
@@ -61,7 +56,6 @@ objects:
   kind: Service
   metadata:
     name: discovery-redis
-    namespace: discovery
   spec:
     selector:
       app: discovery-redis
@@ -78,7 +72,6 @@ objects:
   kind: Service
   metadata:
     name: discovery-db
-    namespace: discovery
   spec:
     selector:
       app: discovery-db
@@ -95,9 +88,8 @@ objects:
   kind: Route
   metadata:
     name: discovery-server
-    namespace: discovery
   spec:
-    host: ${DISCOVERY_SERVER_EXTERNAL_HOSTNAME}
+    host: ${APPLICATION_DOMAIN}
     port:
       targetPort: ${{DISCOVERY_SERVER_PORT}}
     tls:
@@ -111,13 +103,12 @@ objects:
   status:
     ingress:
     - conditions:
-      host: ${DISCOVERY_SERVER_EXTERNAL_HOSTNAME}
+      host: ${APPLICATION_DOMAIN}
       wildcardPolicy: None
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: discovery-server
-    namespace: discovery
   spec:
     replicas: 1
     selector:
@@ -229,7 +220,6 @@ objects:
   kind: Deployment
   metadata:
     name: discovery-celery-worker
-    namespace: discovery
   spec:
     replicas: "${{DISCOVERY_CELERY_WORKER_MINIMUM_REPLICA_COUNT}}"
     selector:
@@ -289,7 +279,6 @@ objects:
   kind: Deployment
   metadata:
     name: discovery-db
-    namespace: discovery
   spec:
     replicas: 1
     selector:
@@ -350,7 +339,6 @@ objects:
   kind: Deployment
   metadata:
     name: discovery-redis
-    namespace: discovery
   spec:
     replicas: 1
     selector:
@@ -405,6 +393,10 @@ objects:
     triggers:
     - type: ConfigChange
 parameters:
+- name: APPLICATION_DOMAIN
+  displayName: Application Hostname
+  description: This is the externally accessible URL for the Discovery server.
+  value: "discovery-server-discovery.apps-crc.testing"
 - name: ANSIBLE_REMOTE_TMP
   displayName: Path for the Ansible Remote Temp directory.
   description: This is the path for the ansible remote temp directory (overrides /.ansible/tmp).
@@ -429,10 +421,6 @@ parameters:
   displayName: Discovery Celery Worker Minimum Replica Count
   description: This is the starting number of Celery workers replicas requested.
   value: '3'
-- name: DISCOVERY_SERVER_EXTERNAL_HOSTNAME
-  displayName: Discovery Server Host Name
-  description: This is the external host name of the Discovery server.
-  value: "discovery-server-discovery.apps-crc.testing"
 - name: DISCOVERY_SERVER_CLUSTER_HOSTNAME
   displayName: Discovery Server Cluster Host Name
   description: This is the internal host name of the Discovery server.

--- a/discovery_template.yaml
+++ b/discovery_template.yaml
@@ -156,7 +156,7 @@ objects:
                 scheme: HTTPS
                 httpHeaders:
                   - name: Host
-                    value: ${DISCOVERY_SERVER_CLUSTER_HOSTNAME}
+                    value: "discovery-server.${DISCOVERY_NAMESPACE}.svc.cluster.local"
               failureThreshold: 5
               initialDelaySeconds: 10
               periodSeconds: 10
@@ -181,7 +181,7 @@ objects:
               - name: QPC_DBMS_DATABASE
                 value: "qpc"
               - name: QPC_DBMS_HOST
-                value: "${DISCOVERY_DBMS_CLUSTER_HOSTNAME}"
+                value: "discovery-db.${DISCOVERY_NAMESPACE}.svc.cluster.local"
               - name: QPC_DBMS_PASSWORD
                 value: "qpc"
               - name: QPC_DBMS_PORT
@@ -201,7 +201,7 @@ objects:
               - name: QPC_LOG_ALL_ENV_VARS_AT_STARTUP
                 value: "False"
               - name: REDIS_HOST
-                value: "${DISCOVERY_REDIS_CLUSTER_HOSTNAME}"
+                value: "discovery-redis.${DISCOVERY_NAMESPACE}.svc.cluster.local"
               - name: REDIS_PASSWORD
                 value: "qpc"
         imagePullSecrets:
@@ -260,7 +260,7 @@ objects:
               - name: DJANGO_SECRET_PATH
                 value: "${DJANGO_SECRET_PATH}"
               - name: REDIS_HOST
-                value: "${DISCOVERY_REDIS_CLUSTER_HOSTNAME}"
+                value: "discovery-redis.${DISCOVERY_NAMESPACE}.svc.cluster.local"
               - name: REDIS_PASSWORD
                 value: "qpc"
         imagePullSecrets:
@@ -393,6 +393,10 @@ objects:
     triggers:
     - type: ConfigChange
 parameters:
+- name: DISCOVERY_NAMESPACE
+  displayName: Discovery Project namespace
+  description: This is the OpenShift project namespace where Discovery is getting installed.
+  value: "discovery"
 - name: APPLICATION_DOMAIN
   displayName: Application Hostname
   description: This is the externally accessible URL for the Discovery server.
@@ -412,7 +416,7 @@ parameters:
 - name: DISCOVERY_SERVER_IMAGE
   displayName: Container image for the Discovery server.
   description: This is the image for the Discovery server.
-  value: "quay.io/abellott/quipucords:latest"
+  value: "quay.io/quipucords/quipucords:latest"
 - name: DISCOVERY_SA_NAME
   displayName: Discovery Service Account Name
   description: This is the name for the Discovery Service Account.
@@ -421,26 +425,14 @@ parameters:
   displayName: Discovery Celery Worker Minimum Replica Count
   description: This is the starting number of Celery workers replicas requested.
   value: '3'
-- name: DISCOVERY_SERVER_CLUSTER_HOSTNAME
-  displayName: Discovery Server Cluster Host Name
-  description: This is the internal host name of the Discovery server.
-  value: "discovery-server.discovery.svc.cluster.local"
 - name: DISCOVERY_SERVER_PORT
   displayName: Discovery Server SSL Port (API/UI)
   description: This is the SSL port for the quipucords server.
   value: "8443"
-- name: DISCOVERY_REDIS_CLUSTER_HOSTNAME
-  displayName: Discovery Redis Server Cluster Host Name
-  description: This is the internal host name of the Discovery Redis Server.
-  value: "discovery-redis.discovery.svc.cluster.local"
 - name: DISCOVERY_REDIS_PORT
   displayName: Discovery Redis Port
   description: This is the port for the quipucords redis server.
   value: "6379"
-- name: DISCOVERY_DBMS_CLUSTER_HOSTNAME
-  displayName: Discovery PostgresQL Server Cluster Host Name
-  description: This is the internal host name of the Discovery PostgreSQL database.
-  value: "discovery-db.discovery.svc.cluster.local"
 - name: DISCOVERY_DBMS_PORT
   displayName: Discovery PostgresQL Database Port
   description: This is the port for the quipucords postgresql database.


### PR DESCRIPTION
Parametrize namespace and application domain, also simplified parameters.
    
- Parametrized all things namespace so we can deploy Discovery to multiple namespaces. Also, make sure we prompt for the constructed APPLICATION_DOMAIN as the default is CRC and we need to be able to target any OpenShift.
- Simplified the required parameters. Luckily the OpenShift service local routes are always svc or svc.cluster.local so we don't need to update the application to fetch the ENV provided <service>_HOST IP addresses.
