### PR TITLE
chore: reduce the default PV claim sizes

### DIFF
--- a/discovery_template.yaml
+++ b/discovery_template.yaml
@@ -24,7 +24,7 @@ objects:
     volumeMode: Filesystem
     resources:
       requests:
-        storage: 32Gi
+        storage: 8Gi
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -35,7 +35,7 @@ objects:
     volumeMode: Filesystem
     resources:
       requests:
-        storage: 16Gi
+        storage: 4Gi
 - apiVersion: v1
   kind: Service
   metadata:
@@ -306,7 +306,7 @@ objects:
               seccompProfile:
                 type: "RuntimeDefault"
             volumeMounts:
-            - mountPath: /var/lib/psql/data
+            - mountPath: /var/lib/pgsql/data
               name: discovery-data-volume-claim
             ports:
               - containerPort: ${{DISCOVERY_DBMS_PORT}}


### PR DESCRIPTION
chore: reduce the default PV claim sizes

- For dev/testing, no need to grab the 32Gi (data) and 16Gi (log), cutting that to a quarter size, so 8Gi for data and 4Gi for logs.
- Also, the mount point for postgresl was incorrect, /var/lib/psql/data should have been /var/lib/pgsql/data, we now see both server and pg sharing the pv.

The PVC sizes need to be parameterized.