### PR TITLE
feat: Add support for DJANGO_SECRET_KEY

### DIFF
--- a/discodeploy
+++ b/discodeploy
@@ -11,6 +11,8 @@ export OCP_PASSWORD="${OCP_PASSWORD:=developer}"
 
 export DISCOVERY_NAMESPACE="${DISCOVERY_NAMESPACE:=discovery}"
 
+export DJANGO_SECRET_KEY="${DJANGO_SECRET_KEY:=}"
+
 export DISCOVERY_REGISTRY="${DISCOVERY_REGISTRY:=quay.io}"
 export REGISTRY_USER="${REGISTRY_USER:=quay_user}"
 export REGISTRY_PASSWORD="${REGISTRY_PASSWORD:=}"
@@ -32,7 +34,7 @@ function cmdexec {
 # Let's display and allow for updates to environment variables
 function varupd {
   var="$(echo $1 | tr '[a-z]' '[A-Z]')"
-  if [[ "${var}" == *"PASS"* ]]; then
+  if [[ "${var}" == *"PASS"* || "${var}" == *"KEY" ]]; then
     echo -n "${var} ($(echo ${!var} | sed 's/./*/g')): "
     read -s value
     echo ""
@@ -70,6 +72,7 @@ function get_env_deploy {
   varupd APPLICATION_DOMAIN
   varupd DISCOVERY_REGISTRY
   varupd QUIPUCORDS_IMAGE_TAG
+  varupd DJANGO_SECRET_KEY
   varupd REGISTRY_USER
   export REGISTRY_BASE="${DISCOVERY_REGISTRY}/${REGISTRY_USER}"
   varupd REGISTRY_BASE
@@ -172,11 +175,19 @@ function cmd_deploy {
     cmd_create_pull_secret
   fi
   cmdexec oc apply -f discovery_template.yaml
-  cmdexec oc new-app --template=discovery \
-    --param=DISCOVERY_SERVER_IMAGE="${DISCOVERY_SERVER_IMAGE}" \
-    --param=DISCOVERY_NAMESPACE=${DISCOVERY_NAMESPACE} \
-    --param=APPLICATION_DOMAIN="${APPLICATION_DOMAIN}"
-
+  if [ -z "${DJANGO_SECRET_KEY}" ]
+  then
+    cmdexec oc new-app --template=discovery \
+      --param=DISCOVERY_SERVER_IMAGE="${DISCOVERY_SERVER_IMAGE}" \
+      --param=DISCOVERY_NAMESPACE=${DISCOVERY_NAMESPACE} \
+      --param=APPLICATION_DOMAIN="${APPLICATION_DOMAIN}"
+  else
+    cmdexec oc new-app --template=discovery \
+      --param=DISCOVERY_SERVER_IMAGE="${DISCOVERY_SERVER_IMAGE}" \
+      --param=DISCOVERY_NAMESPACE=${DISCOVERY_NAMESPACE} \
+      --param=APPLICATION_DOMAIN="${APPLICATION_DOMAIN}" \
+      --param=DJANGO_SECRET_KEY="`echo ${DJANGO_SECRET_KEY} | base64`"
+  fi
   echo ""
   echo "Application Url: https://${APPLICATION_DOMAIN}"
 }
@@ -210,6 +221,8 @@ function cmd_undeploy {
   oc delete --ignore-not-found=true pvc/discovery-log-volume-claim
   echo "Deleting Service Accounts ..."
   oc delete --ignore-not-found=true sa/discovery-sa
+  echo "Deleting Discovery Secrets ..."
+  oc delete --ignore-not-found=true secrets/discovery-secrets
   echo "Deleting Discovery Template ..."
   oc delete --ignore-not-found=true -f discovery_template.yaml
 }
@@ -257,6 +270,7 @@ Environment variables that are honored and prompted for (defaults):
     OCP_PASSWORD               (developer)
     DISCOVERY_NAMESPACE        (discovery)
     APPLICATION_DOMAIN         (discovery-server-discovery.apps-crc.testing)
+    DJANGO_SECRET_KEY          ()  Template default is: development
  
     DISCOVERY_REGISTRY         (quay.io)
     REGISTRY_USER              (quay_user)

--- a/discovery_template.yaml
+++ b/discovery_template.yaml
@@ -15,6 +15,12 @@ objects:
   metadata:
     name: ${DISCOVERY_SA_NAME}
 - apiVersion: v1
+  kind: Secret
+  metadata:
+    name: discovery-secrets
+  data:
+    django-secret-key: ${DJANGO_SECRET_KEY}
+- apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: discovery-data-volume-claim
@@ -176,6 +182,11 @@ objects:
                 value: "3"
               - name: DJANGO_SECRET_PATH
                 value: "${DJANGO_SECRET_PATH}"
+              - name: DJANGO_SECRET_KEY
+                valueFrom:
+                  secretKeyRef:
+                    key: django-secret-key
+                    name: discovery-secrets
               - name: QPC_DBMS
                 value: "postgres"
               - name: QPC_DBMS_DATABASE
@@ -259,6 +270,11 @@ objects:
                 value: "${ANSIBLE_LOCAL_TEMP}"
               - name: DJANGO_SECRET_PATH
                 value: "${DJANGO_SECRET_PATH}"
+              - name: DJANGO_SECRET_KEY
+                valueFrom:
+                  secretKeyRef:
+                    key: django-secret-key
+                    name: discovery-secrets
               - name: REDIS_HOST
                 value: "discovery-redis.${DISCOVERY_NAMESPACE}.svc.cluster.local"
               - name: REDIS_PASSWORD
@@ -412,7 +428,11 @@ parameters:
 - name: DJANGO_SECRET_PATH
   displayName: Path for the Django secret
   description: This is the path for the Django secret
-  value: "/app/quipucords/secret.txt"
+  value: "/var/data/secret.txt"
+- name: DJANGO_SECRET_KEY
+  displayName: Django secret key
+  description: This is the Django App Secret key
+  value: "ZGV2ZWxvcG1lbnQK"
 - name: DISCOVERY_SERVER_IMAGE
   displayName: Container image for the Discovery server.
   description: This is the image for the Discovery server.


### PR DESCRIPTION
feat: Add support for DJANGO_SECRET_KEY

This adds support for DJANGO_SECRET_KEY, defaulting to a template provided one. the DJANGO_SECRET_KEY is saved in a discovery-secrets secret as "django-secret-key" and is referenced as such.

With the DJANGO_SECRET_KEY defined in the OCP deployments, we now define the PATH as /var/data/secret.txt as we'd be writing to that location which is the writable data PV.