### PR TITLE
feature(password): Add support for user specified admin password

### DIFF
--- a/discodeploy
+++ b/discodeploy
@@ -38,13 +38,33 @@ function cmdexec() {
 function varupd() {
   var=$(echo "$1" | tr '[:lower:]' '[:upper:]')
   if [[ "${var}" == *"PASS"* || "${var}" == *"KEY" ]]; then
-    if [[ "${!var}" == "" ]]; then
-      echo -n "${var} (): "
-    else
-      echo -n "${var} (********): "
-    fi
-    read -rs value
-    echo ""
+    while :
+    do
+      if [[ "${!var}" == "" ]]; then
+        echo -n "${var} (): "
+      else
+        echo -n "${var} (********): "
+      fi
+      read -rs value
+      if [ -n "${value}" ]; then
+        echo ""
+        echo -n "Re-enter ${var} : "
+        read -rs value2
+        if [ ! "${value2}" = "${value}" ]; then
+          echo ""
+          echo "Password or token do not match"
+          continue
+        fi
+      else
+        if [[ "${var}" == *"PASS"* && "${!var}" == "" ]]; then
+          echo ""
+          echo "Must specify a password"
+          continue
+        fi
+      fi
+      echo ""
+      break
+    done
   else
     echo -n "${var} (${!var}): "
     read -r value
@@ -57,8 +77,22 @@ function get_server_password() {
   do
     varupd DISCOVERY_SERVER_PASSWORD
     [[ -z "${DISCOVERY_SERVER_PASSWORD}" ]] && echo "Must specify a server password" && continue
-    [[ "${DISCOVERY_SERVER_PASSWORD}" == "qpcpassw0rd" ]] && echo "Server password can no longer be the default value" && continue
-    [[ ${#DISCOVERY_SERVER_PASSWORD} -lt 10 ]] && echo "Server password must be at least 10 characters long" && continue
+    REJECTED_PASSWORDS=("qpcpassw0rd" "dscpassw0rd")
+    if [[ ${REJECTED_PASSWORDS[@]} =~ "${DISCOVERY_SERVER_PASSWORD}" ]]; then
+      DISCOVERY_SERVER_PASSWORD=""
+      echo "Server password can no longer be the default value"
+      continue
+    fi
+    if [[ "${DISCOVERY_SERVER_PASSWORD}" =~ ^[0-9]+$ ]]; then
+      DISCOVERY_SERVER_PASSWORD=""
+      echo "Server password specified is all numeric"
+      continue
+    fi
+    if [ ${#DISCOVERY_SERVER_PASSWORD} -lt 10 ]; then
+      DISCOVERY_SERVER_PASSWORD=""
+      echo "Server password must be at least 10 characters long"
+      continue
+    fi
     break
   done
 }

--- a/discodeploy
+++ b/discodeploy
@@ -40,29 +40,21 @@ function varupd() {
   if [[ "${var}" == *"PASS"* || "${var}" == *"KEY" ]]; then
     while :
     do
-      if [[ "${!var}" == "" ]]; then
-        echo -n "${var} (): "
-      else
-        echo -n "${var} (********): "
-      fi
-      read -rs value
+      read -rs -p "${var} (${!var:+********}): " value
+      echo
       if [ -n "${value}" ]; then
-        echo ""
-        echo -n "Re-enter ${var} : "
-        read -rs value2
+        read -rs -p "Re-enter ${var}: " value2
+        echo
         if [ ! "${value2}" = "${value}" ]; then
-          echo ""
-          echo "Password or token do not match"
+          echo "Values do not match."
           continue
         fi
       else
         if [[ "${var}" == *"PASS"* && "${!var}" == "" ]]; then
-          echo ""
-          echo "Must specify a password"
+          echo "Must specify a password."
           continue
         fi
       fi
-      echo ""
       break
     done
   else

--- a/discodeploy
+++ b/discodeploy
@@ -12,6 +12,7 @@ export OCP_PASSWORD="${OCP_PASSWORD:=developer}"
 export DISCOVERY_NAMESPACE="${DISCOVERY_NAMESPACE:=discovery}"
 export APPLICATION_DOMAIN_SUFFIX="${APPLICATION_DOMAIN_SUFFIX:=apps-crc.testing}"
 
+export DISCOVERY_SERVER_PASSWORD="${DISCOVERY_SERVER_PASSWORD:=}"
 export DJANGO_SECRET_KEY="${DJANGO_SECRET_KEY:=}"
 
 export DISCOVERY_REGISTRY="${DISCOVERY_REGISTRY:=quay.io}"
@@ -51,6 +52,17 @@ function varupd() {
   [[ -n "${value}" ]] && export "${1}"="${value}"
 }
 
+function get_server_password() {
+  while :
+  do
+    varupd DISCOVERY_SERVER_PASSWORD
+    [[ -z "${DISCOVERY_SERVER_PASSWORD}" ]] && echo "Must specify a server password" && continue
+    [[ "${DISCOVERY_SERVER_PASSWORD}" == "qpcpassw0rd" ]] && echo "Server password can no longer be the default value" && continue
+    [[ ${#DISCOVERY_SERVER_PASSWORD} -lt 10 ]] && echo "Server password must be at least 10 characters long" && continue
+    break
+  done
+}
+
 function default_registry_email() {
   if [ -z "${REGISTRY_EMAIL}" ]; then
     export REGISTRY_EMAIL="${REGISTRY_USER}@redhat.com"
@@ -85,6 +97,7 @@ function get_env_deploy() {
   varupd QUIPUCORDS_IMAGE_TAG
   export DISCOVERY_SERVER_IMAGE="${DISCOVERY_REGISTRY}/${REGISTRY_ACCOUNT}/${QUIPUCORDS_IMAGE}:${QUIPUCORDS_IMAGE_TAG}"
   varupd DISCOVERY_SERVER_IMAGE
+  get_server_password
   varupd DJANGO_SECRET_KEY
   varupd REGISTRY_USER
 }
@@ -177,11 +190,13 @@ function cmd_deploy() {
   if [ -z "${DJANGO_SECRET_KEY}" ]; then
     cmdexec oc new-app --template=discovery \
       --param=DISCOVERY_SERVER_IMAGE="${DISCOVERY_SERVER_IMAGE}" \
+      --param=DISCOVERY_SERVER_PASSWORD="$(echo -n "${DISCOVERY_SERVER_PASSWORD}" | base64)" \
       --param=DISCOVERY_NAMESPACE="${DISCOVERY_NAMESPACE}" \
       --param=APPLICATION_DOMAIN="${APPLICATION_DOMAIN}"
   else
     cmdexec oc new-app --template=discovery \
       --param=DISCOVERY_SERVER_IMAGE="${DISCOVERY_SERVER_IMAGE}" \
+      --param=DISCOVERY_SERVER_PASSWORD="$(echo -n "${DISCOVERY_SERVER_PASSWORD}" | base64)" \
       --param=DISCOVERY_NAMESPACE="${DISCOVERY_NAMESPACE}" \
       --param=APPLICATION_DOMAIN="${APPLICATION_DOMAIN}" \
       --param=DJANGO_SECRET_KEY="$(echo "${DJANGO_SECRET_KEY}" | base64)"

--- a/discovery_template.yaml
+++ b/discovery_template.yaml
@@ -20,6 +20,7 @@ objects:
     name: discovery-secrets
   data:
     django-secret-key: ${DJANGO_SECRET_KEY}
+    server-password: ${DISCOVERY_SERVER_PASSWORD}
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -203,6 +204,13 @@ objects:
                 value: "${DISCOVERY_SERVER_PORT}"
               - name: QPC_SERVER_TIMEOUT
                 value: "5"
+              - name: QPC_SERVER_USERNAME
+                value: "${DISCOVERY_SERVER_USERNAME}"
+              - name: QPC_SERVER_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: server-password
+                    name: discovery-secrets
               - name: NETWORK_CONNECT_JOB_TIMEOUT
                 value: "6"
               - name: NETWORK_INSPECT_JOB_TIMEOUT
@@ -437,6 +445,14 @@ parameters:
   displayName: Container image for the Discovery server.
   description: This is the image for the Discovery server.
   value: "quay.io/quipucords/quipucords:latest"
+- name: DISCOVERY_SERVER_USERNAME
+  displayName: Discovery server admin user account.
+  description: This is the admin user account for the Discovery server.
+  value: "admin"
+- name: DISCOVERY_SERVER_PASSWORD
+  displayName: Discovery server admin password.
+  description: This is the password for the admin user account of the Discovery server.
+  value: ""
 - name: DISCOVERY_SA_NAME
   displayName: Discovery Service Account Name
   description: This is the name for the Discovery Service Account.


### PR DESCRIPTION
feature(password): Add support for user specified admin password

- Leveraging https://github.com/quipucords/quipucords/pull/2502 for specifying the required QPC_SERVER_PASSWORD
- discodeploy script now prompts for DISCOVERY_SERVER_PASSWORD
- Stores the server admin password in the discovery-server secret as the key "server-password"
- Defines the server deployment's QPC_SERVER_PASSWORD to fetch the server password from the secret.